### PR TITLE
Replace discontinued flutter_markdown with flutter_markdown_plus

### DIFF
--- a/citta/lib/screens/session_detail_screen.dart
+++ b/citta/lib/screens/session_detail_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import '../models/session_model.dart';
 import '../theme/app_theme.dart';
 

--- a/citta/pubspec.yaml
+++ b/citta/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   just_audio: ^0.9.36
   file_picker: ^8.0.0
   share_plus: ^10.0.0
-  flutter_markdown: ^0.6.18
+  flutter_markdown_plus: ^1.0.0
   intl: ^0.19.0
   cupertino_icons: ^1.0.6
   wakelock_plus: ^1.2.8


### PR DESCRIPTION
## Summary
Replaced the discontinued `flutter_markdown` package with `flutter_markdown_plus`.

## Changes Made
- Updated dependency in pubspec.yaml
- Updated all imports from:
  package:flutter_markdown/flutter_markdown.dart
  to:
  package:flutter_markdown_plus/flutter_markdown_plus.dart
- Ran flutter clean and flutter pub get
- Verified app builds successfully

## Verification
- App builds without warnings
- No deprecated packages remain
- Markdown rendering works as expected