### PR TITLE
fix(android): make release config production-ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,20 +49,10 @@ jobs:
         run: flutter build apk --debug
         working-directory: citta
 
-      - name: Build release APK
-        run: flutter build apk --release
-        working-directory: citta
-
       - uses: actions/upload-artifact@v4
         with:
           name: app-debug-apk
           path: citta/build/app/outputs/flutter-apk/app-debug.apk
-          retention-days: 30
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: app-release-apk
-          path: citta/build/app/outputs/flutter-apk/app-release.apk
           retention-days: 30
 
   release:
@@ -85,6 +75,18 @@ jobs:
 
       - run: flutter pub get
         working-directory: citta
+
+      - name: Decode keystore
+        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > $HOME/citta-release.jks
+
+      - name: Create key.properties
+        run: |
+          cat > citta/android/key.properties <<EOF
+          storeFile=$HOME/citta-release.jks
+          storePassword=${{ secrets.ANDROID_STORE_PASSWORD }}
+          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
+          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+          EOF
 
       - name: Build debug APK
         run: flutter build apk --debug

--- a/citta/android/app/build.gradle.kts
+++ b/citta/android/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
     }
 
     signingConfigs {
-        create("release") {
-            if (keyPropertiesFile.exists()) {
+        if (keyPropertiesFile.exists()) {
+            create("release") {
                 keyAlias = keyProperties["keyAlias"] as String
                 keyPassword = keyProperties["keyPassword"] as String
                 storeFile = file(keyProperties["storeFile"] as String)
@@ -51,7 +51,23 @@ android {
             signingConfig = if (keyPropertiesFile.exists()) {
                 signingConfigs.getByName("release")
             } else {
-                signingConfigs.getByName("debug")
+                null
+            }
+        }
+    }
+}
+
+// Fail loudly when a release artifact is requested without signing config.
+// Use debug builds (flutter build apk --debug) for local dev without a keystore.
+tasks.configureEach {
+    if ((name.startsWith("assemble") || name.startsWith("bundle")) && name.contains("Release")) {
+        doFirst {
+            if (!keyPropertiesFile.exists()) {
+                throw GradleException(
+                    "\nRelease signing requires android/key.properties.\n" +
+                    "See android/key.properties.example for setup instructions.\n" +
+                    "Use 'flutter build apk --debug' for local development without a release keystore."
+                )
             }
         }
     }

--- a/citta/android/app/build.gradle.kts
+++ b/citta/android/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -5,8 +8,13 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+val keyPropertiesFile = rootProject.file("key.properties")
+val keyProperties = Properties().apply {
+    if (keyPropertiesFile.exists()) load(FileInputStream(keyPropertiesFile))
+}
+
 android {
-    namespace = "com.example.citta"
+    namespace = "com.hkadekar.citta"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -19,11 +27,19 @@ android {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
+    signingConfigs {
+        create("release") {
+            if (keyPropertiesFile.exists()) {
+                keyAlias = keyProperties["keyAlias"] as String
+                keyPassword = keyProperties["keyPassword"] as String
+                storeFile = file(keyProperties["storeFile"] as String)
+                storePassword = keyProperties["storePassword"] as String
+            }
+        }
+    }
+
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.citta"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
+        applicationId = "com.hkadekar.citta"
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
@@ -32,9 +48,11 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = if (keyPropertiesFile.exists()) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 }

--- a/citta/android/app/src/main/kotlin/com/hkadekar/citta/MainActivity.kt
+++ b/citta/android/app/src/main/kotlin/com/hkadekar/citta/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.citta
+package com.hkadekar.citta
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/citta/android/key.properties.example
+++ b/citta/android/key.properties.example
@@ -1,0 +1,4 @@
+storeFile=/path/to/citta-release.jks
+storePassword=your-store-password
+keyAlias=citta
+keyPassword=your-key-password


### PR DESCRIPTION
## Summary

- Renames package from `com.example.citta` to `com.hkadekar.citta` (namespace, applicationId, MainActivity.kt)
- Adds release signing config reading from `android/key.properties`; fails loudly (GradleException) when `key.properties` is absent instead of silently falling back to debug signing
- Adds `android/key.properties.example` as a committed setup guide
- Updates CI: `build` job builds debug APK only on every push; `release` job decodes keystore from GitHub Secrets and builds the release-signed APK on tagged pushes

## Test plan

- [x] `flutter analyze` - no issues
- [x] All 155 tests pass
- [x] Codex review - no findings on second pass
- [ ] Release signing end-to-end: exercised when a `v*` tag is pushed with ANDROID_KEYSTORE_BASE64 / ANDROID_STORE_PASSWORD / ANDROID_KEY_ALIAS / ANDROID_KEY_PASSWORD secrets configured

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)