### PR TITLE
chore(ship): replace direct master push with PR creation step

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -51,9 +51,10 @@ Use `git add` with specific file paths — never `git add -A` or `git add .`.
 - Example: `feat(audio): pre-initialize player on app start`
 - Always append: `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
 
-## 8. Push
+## 8. Create a pull request
+Push the branch to remote and open a PR — never push directly to master:
 ```
-git push origin master
+git push origin <branch-name>
+gh pr create --title "<title>" --body "<body>"
 ```
-
-Report the commit hash and confirm the push succeeded.
+Return the PR URL so the user can review and merge it.


### PR DESCRIPTION
## Summary
- Updates the `/ship` skill to push to a feature branch and open a PR instead of pushing directly to `master`
- Reflects the project convention that all changes go through PRs

## Test plan
- [ ] Verify the skill step reads correctly