### PR TITLE
fix(storage): remove dead StorageService.addSession() method

### DIFF
--- a/citta/lib/services/storage_service.dart
+++ b/citta/lib/services/storage_service.dart
@@ -146,12 +146,6 @@ class StorageService {
     await _atomicWrite(path, content);
   }
 
-  Future<void> addSession(SessionModel session) async {
-    final sessions = await loadSessions();
-    sessions.add(session);
-    await saveSessions(sessions);
-  }
-
   // --- User Quotes ---
 
   Future<String> get _userQuotesPath async =>

--- a/citta/test/services/quote_service_test.dart
+++ b/citta/test/services/quote_service_test.dart
@@ -37,8 +37,6 @@ class FakeStorageService extends StorageService {
   Future<List<SessionModel>> loadSessions() async => [];
   @override
   Future<void> saveSessions(List<SessionModel> sessions) async {}
-  @override
-  Future<void> addSession(SessionModel session) async {}
 }
 
 // ---------------------------------------------------------------------------

--- a/citta/test/services/storage_service_test.dart
+++ b/citta/test/services/storage_service_test.dart
@@ -301,30 +301,6 @@ void main() {
     });
   });
 
-  group('addSession', () {
-    test('appends session to empty store', () async {
-      await service.addSession(_makeSession(id: 's1'));
-      final sessions = await service.loadSessions();
-      expect(sessions.length, 1);
-      expect(sessions.first.id, 's1');
-    });
-
-    test('appends session to existing sessions', () async {
-      await service.saveSessions([_makeSession(id: 's1')]);
-      await service.addSession(_makeSession(id: 's2'));
-      final sessions = await service.loadSessions();
-      expect(sessions.length, 2);
-      expect(sessions.last.id, 's2');
-    });
-
-    test('multiple addSession calls accumulate', () async {
-      for (var i = 1; i <= 5; i++) {
-        await service.addSession(_makeSession(id: 's$i'));
-      }
-      expect(await service.loadSessions(), hasLength(5));
-    });
-  });
-
   // -------------------------------------------------------------------------
   // User Quotes
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes `StorageService.addSession()` — confirmed dead code with no production call sites
- `AppState.addSession()` is the single owned path for session persistence (updates in-memory list, then calls `storageService.saveSessions()`)
- Removes the method's 3 unit tests from `storage_service_test.dart`
- Removes the no-op stub from `FakeStorageService` in `quote_service_test.dart`

Closes #17

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 183 tests pass
- [x] Code review — no findings
- [x] Codex review — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)