### PR TITLE
perf(app-state): cache derived session data (issue #10)

### DIFF
--- a/citta/lib/providers/app_state.dart
+++ b/citta/lib/providers/app_state.dart
@@ -14,6 +14,14 @@ class AppState extends ChangeNotifier {
 
   ConfigModel _config = ConfigModel();
   List<SessionModel> _sessions = const [];
+  List<SessionModel> _sortedSessions = const [];
+  StatsResult _stats = const StatsResult(
+    totalSessions: 0,
+    currentStreak: 0,
+    longestStreak: 0,
+    averageDurationSeconds: 0,
+    totalDurationSeconds: 0,
+  );
   bool _isLoading = true;
 
   AppState({
@@ -26,7 +34,14 @@ class AppState extends ChangeNotifier {
   ConfigModel get config => _config;
   List<SessionModel> get sessions => _sessions;
   bool get isLoading => _isLoading;
-  StatsResult get stats => statsService.calculateStats(_sessions);
+  StatsResult get stats => _stats;
+
+  void _refreshDerivedData() {
+    final sorted = List<SessionModel>.from(_sessions)
+      ..sort((a, b) => b.date.compareTo(a.date));
+    _sortedSessions = List.unmodifiable(sorted);
+    _stats = statsService.calculateStats(_sessions);
+  }
 
   Locale? get locale =>
       _config.language == 'system' ? null : Locale(_config.language);
@@ -41,6 +56,7 @@ class AppState extends ChangeNotifier {
     await audioService.init();
     audioService.warmUp(_config.bellEnd); // fire-and-forget — completes well before first session
 
+    _refreshDerivedData();
     _isLoading = false;
     notifyListeners();
   }
@@ -61,14 +77,11 @@ class AppState extends ChangeNotifier {
   Future<void> addSession(SessionModel session) async {
     _sessions = List.unmodifiable([..._sessions, session]);
     await storageService.saveSessions(_sessions);
+    _refreshDerivedData();
     notifyListeners();
   }
 
-  List<SessionModel> get sortedSessions {
-    final sorted = List<SessionModel>.from(_sessions);
-    sorted.sort((a, b) => b.date.compareTo(a.date));
-    return sorted;
-  }
+  List<SessionModel> get sortedSessions => _sortedSessions;
 
   List<SessionModel> filterByTag(String tag) {
     return _sessions.where((s) => s.tags.contains(tag)).toList()
@@ -80,15 +93,15 @@ class AppState extends ChangeNotifier {
       _sessions.where((s) => !sessionIds.contains(s.id)),
     );
     await storageService.saveSessions(_sessions);
+    _refreshDerivedData();
     notifyListeners();
   }
 
   List<SessionModel> filterByTags(List<String> tags) {
-    if (tags.isEmpty) return sortedSessions;
-    return _sessions
+    if (tags.isEmpty) return _sortedSessions;
+    return _sortedSessions
         .where((s) => tags.any((tag) => s.tags.contains(tag)))
-        .toList()
-      ..sort((a, b) => b.date.compareTo(a.date));
+        .toList();
   }
 
   // --- Tags ---
@@ -117,6 +130,7 @@ class AppState extends ChangeNotifier {
     await storageService.importData(data, replaceAll: replaceAll);
     _config = await storageService.loadConfig();
     _sessions = List.unmodifiable(await storageService.loadSessions());
+    _refreshDerivedData();
     await quoteService.reloadUserQuotes();
     notifyListeners();
     return true;

--- a/citta/test/providers/app_state_caching_test.dart
+++ b/citta/test/providers/app_state_caching_test.dart
@@ -1,0 +1,206 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:citta/models/config_model.dart';
+import 'package:citta/models/session_model.dart';
+import 'package:citta/providers/app_state.dart';
+import 'package:citta/services/audio_service.dart';
+import 'package:citta/services/quote_service.dart';
+import 'package:citta/services/stats_service.dart';
+import 'package:citta/services/storage_service.dart';
+import 'package:just_audio/just_audio.dart';
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+class _FakeAudioPlayer implements AudioPlayerBase {
+  @override Future<void> setAsset(String path) async {}
+  @override Future<void> setFilePath(String path) async {}
+  @override Future<void> setLoopMode(LoopMode mode) async {}
+  @override Future<void> setVolume(double volume) async {}
+  @override Future<void> seek(Duration position) async {}
+  @override Future<void> play() async {}
+  @override Future<void> pause() async {}
+  @override Future<void> stop() async {}
+  @override Future<void> dispose() async {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// IMPORTANT: call only from setUp(), never inside testWidgets() or test() with
+// fakeAsync — real async I/O does not complete under fakeAsync.
+Future<AppState> _makeAndInit(String basePath) async {
+  final storage = StorageService.withBasePath(basePath);
+  final appState = AppState(
+    storageService: storage,
+    quoteService: QuoteService(storage),
+    audioService: AudioService.withPlayers(
+      bellPlayer: _FakeAudioPlayer(),
+      musicPlayer: _FakeAudioPlayer(),
+    ),
+    statsService: const StatsService(),
+  );
+  await appState.initialize();
+  return appState;
+}
+
+SessionModel _session(String id, {DateTime? date}) => SessionModel(
+      id: id,
+      date: date ?? DateTime.utc(2024, 6, 1),
+      duration: 300,
+      timerMode: 'countdown',
+    );
+
+String _importJson({List<SessionModel> sessions = const []}) {
+  return jsonEncode({
+    'config': ConfigModel().toJson(),
+    'sessions': sessions.map((s) => s.toJson()).toList(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('AppState derived-data caching — stats', () {
+    late Directory tmpDir;
+    late AppState appState;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('citta_caching_test_');
+      appState = await _makeAndInit(tmpDir.path);
+    });
+
+    tearDown(() => tmpDir.deleteSync(recursive: true));
+
+    test('1. stats returns the same object reference on consecutive reads without mutation',
+        () {
+      final ref1 = appState.stats;
+      final ref2 = appState.stats;
+      expect(identical(ref1, ref2), isTrue,
+          reason: 'stats must be a cached value — recalculating on every get '
+              'wastes CPU on unrelated notifyListeners calls');
+    });
+
+    test('2. stats reference is stable after a config-only updateConfig call',
+        () async {
+      final before = appState.stats;
+      await appState.updateConfig(ConfigModel(countdownDuration: 20));
+      final after = appState.stats;
+      expect(identical(before, after), isTrue,
+          reason: 'a config-only update must not invalidate the stats cache');
+    });
+
+    test('3. stats.totalSessions increments and reference changes after addSession',
+        () async {
+      final before = appState.stats;
+      expect(before.totalSessions, 0);
+      await appState.addSession(_session('s1'));
+      final after = appState.stats;
+      expect(after.totalSessions, 1,
+          reason: 'stats must reflect the new session after addSession');
+      expect(identical(before, after), isFalse,
+          reason: 'stats reference must change when _sessions changes');
+    });
+
+    test('4. stats.totalSessions decrements and reference changes after deleteSessions',
+        () async {
+      await appState.addSession(_session('s1'));
+      await appState.addSession(_session('s2'));
+      final before = appState.stats;
+      expect(before.totalSessions, 2);
+      await appState.deleteSessions(['s1']);
+      final after = appState.stats;
+      expect(after.totalSessions, 1,
+          reason: 'stats must reflect the deletion after deleteSessions');
+      expect(identical(before, after), isFalse,
+          reason: 'stats reference must change when _sessions changes');
+    });
+
+    test('5. stats is updated after importData', () async {
+      final importContent = _importJson(
+        sessions: [_session('imp1'), _session('imp2')],
+      );
+      final ok = await appState.importData(importContent);
+      expect(ok, isTrue);
+      expect(appState.stats.totalSessions, 2,
+          reason: 'stats must reflect imported sessions');
+    });
+  });
+
+  group('AppState derived-data caching — sortedSessions', () {
+    late Directory tmpDir;
+    late AppState appState;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('citta_caching_test_');
+      appState = await _makeAndInit(tmpDir.path);
+    });
+
+    tearDown(() => tmpDir.deleteSync(recursive: true));
+
+    test('6. sortedSessions returns the same object reference on consecutive reads without mutation',
+        () {
+      final ref1 = appState.sortedSessions;
+      final ref2 = appState.sortedSessions;
+      expect(identical(ref1, ref2), isTrue,
+          reason: 'sortedSessions must be cached — sorting on every get wastes '
+              'CPU on unrelated notifyListeners calls');
+    });
+
+    test('7. sortedSessions reference is stable after a config-only updateConfig call',
+        () async {
+      final before = appState.sortedSessions;
+      await appState.updateConfig(ConfigModel(countdownDuration: 20));
+      final after = appState.sortedSessions;
+      expect(identical(before, after), isTrue,
+          reason: 'a config-only update must not invalidate the sortedSessions cache');
+    });
+
+    test('8. sortedSessions includes new session after addSession', () async {
+      await appState.addSession(_session('s1'));
+      expect(appState.sortedSessions.map((s) => s.id), contains('s1'),
+          reason: 'sortedSessions must include the new session after addSession');
+    });
+
+    test('9. sortedSessions excludes deleted session after deleteSessions',
+        () async {
+      await appState.addSession(_session('s1'));
+      await appState.deleteSessions(['s1']);
+      expect(appState.sortedSessions.map((s) => s.id), isNot(contains('s1')),
+          reason: 'sortedSessions must not include deleted sessions');
+    });
+
+    test('10. sortedSessions is ordered newest-first', () async {
+      final older = _session('old', date: DateTime.utc(2024, 1, 1));
+      final newer = _session('new', date: DateTime.utc(2024, 6, 1));
+      await appState.addSession(older);
+      await appState.addSession(newer);
+      final ids = appState.sortedSessions.map((s) => s.id).toList();
+      expect(ids.first, 'new',
+          reason: 'sortedSessions must be sorted newest-first (descending by date)');
+      expect(ids.last, 'old');
+    });
+
+    test('11. filterByTags([]) returns the same reference as sortedSessions',
+        () {
+      final sorted = appState.sortedSessions;
+      final filtered = appState.filterByTags([]);
+      expect(identical(sorted, filtered), isTrue,
+          reason: 'filterByTags([]) must return the cached sortedSessions — '
+              'not a newly allocated copy');
+    });
+
+    test('12. sortedSessions is unmodifiable — external mutation throws', () {
+      expect(
+        () => appState.sortedSessions.add(_session('x')),
+        throwsUnsupportedError,
+        reason: 'sortedSessions must be unmodifiable to prevent accidental mutation',
+      );
+    });
+  });
+}

--- a/docs/codex-review.md
+++ b/docs/codex-review.md
@@ -61,3 +61,38 @@ The earlier gap is closed: [audio_service_test.dart](/home/harsha/workspace/Citt
 ## Summary
 
 No findings on the current revision. The issue’s new interruption/state tests now cover the stop-failure path correctly, and the focused audio service test file passes.
+
+---
+
+## Scope
+
+Review of the current local changes for GitHub issue `#10`: `Cache derived session state in AppState`.
+
+Issue requirement reviewed against:
+
+- Cache derived session data in `AppState` and recompute it only when `_sessions` changes
+- Avoid repeated sorting/stat recomputation on unrelated config updates
+- Preserve existing UI behavior for history and stats consumers
+
+## Findings
+
+No code-review findings in the current branch state.
+
+The implementation now keeps stable cached values for both `stats` and `sortedSessions` in [app_state.dart](/home/harsha/workspace/Citta/citta/lib/providers/app_state.dart:17), refreshes them only from the session mutation paths in [app_state.dart](/home/harsha/workspace/Citta/citta/lib/providers/app_state.dart:39), and reuses the cached sorted list for the empty-tag fast path in [app_state.dart](/home/harsha/workspace/Citta/citta/lib/providers/app_state.dart:100). The new regression coverage in [app_state_caching_test.dart](/home/harsha/workspace/Citta/citta/test/providers/app_state_caching_test.dart:1) verifies reference stability across config-only updates and correctness after session mutations/import.
+
+## Verification
+
+- Reviewed issue `#10` via `gh issue view 10 --repo harsha-kadekar/citta --json number,title,body,state,labels,url`
+- Inspected the local diff in:
+  - `citta/lib/providers/app_state.dart`
+  - `citta/test/providers/app_state_caching_test.dart`
+- Read the affected consumers in:
+  - `citta/lib/screens/history_screen.dart`
+  - `citta/lib/screens/stats_screen.dart`
+  - `citta/lib/widgets/calendar_view.dart`
+- Ran `/home/harsha/flutter/flutter/bin/flutter test test/providers/app_state_caching_test.dart`
+  - Result: passes
+
+## Summary
+
+No findings on the current revision. The change addresses the intended recomputation hotspots without altering the observable behavior of the history or stats consumers, and the targeted caching tests pass.


### PR DESCRIPTION
## Summary

- Add `_sortedSessions` and `_stats` cached fields to `AppState`, computed only when `_sessions` changes
- `_refreshDerivedData()` is called inside `initialize()`, `addSession()`, `deleteSessions()`, and `importData()` — the only four paths that mutate `_sessions`
- Config-only updates (theme, language, calendar toggle) no longer trigger a sort or stats recalculation
- `filterByTags(nonEmpty)` now filters the already-sorted `_sortedSessions` instead of re-sorting from `_sessions` on every call
- `_refreshDerivedData()` is placed **after** `storageService.saveSessions()` so a storage failure never leaves the caches ahead of persisted data

## Test plan

- [ ] New test file `test/providers/app_state_caching_test.dart` (12 tests) covers reference stability on repeated reads, stability across config-only updates, correct invalidation after `addSession`/`deleteSessions`/`importData`, newest-first ordering, `filterByTags([])` reference equality with `sortedSessions`, and unmodifiability
- [ ] All 215 tests pass
- [ ] `flutter analyze` reports no issues
- [ ] Codex review: no findings (`docs/codex-review.md`)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)