### PR TITLE
Extract shared duration and date formatter utilities

### DIFF
--- a/citta/lib/l10n/app_ar.arb
+++ b/citta/lib/l10n/app_ar.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "اكتملت الجلسة",
   "sessionTitle": "الجلسة",
+  "sessionDateAt": "{date} في {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "مكتمل",

--- a/citta/lib/l10n/app_as.arb
+++ b/citta/lib/l10n/app_as.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "অধিৱেশন সম্পূৰ্ণ",
   "sessionTitle": "অধিৱেশন",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "সম্পূৰ্ণ",

--- a/citta/lib/l10n/app_bn.arb
+++ b/citta/lib/l10n/app_bn.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "সেশন সম্পূর্ণ",
   "sessionTitle": "সেশন",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "সম্পূর্ণ",

--- a/citta/lib/l10n/app_de.arb
+++ b/citta/lib/l10n/app_de.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "Sitzung abgeschlossen",
   "sessionTitle": "Sitzung",
+  "sessionDateAt": "{date} um {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stoppuhr",
   "sessionCompleted": "Abgeschlossen",

--- a/citta/lib/l10n/app_en.arb
+++ b/citta/lib/l10n/app_en.arb
@@ -322,6 +322,14 @@
   "sessionTitle": "Session",
   "@sessionTitle": {},
 
+  "sessionDateAt": "{date} at {time}",
+  "@sessionDateAt": {
+    "placeholders": {
+      "date": { "type": "String" },
+      "time": { "type": "String" }
+    }
+  },
+
   "sessionCountdown": "Countdown",
   "@sessionCountdown": {},
 

--- a/citta/lib/l10n/app_es.arb
+++ b/citta/lib/l10n/app_es.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "Sesión completa",
   "sessionTitle": "Sesión",
+  "sessionDateAt": "{date} a las {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "Completado",

--- a/citta/lib/l10n/app_fr.arb
+++ b/citta/lib/l10n/app_fr.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "Séance terminée",
   "sessionTitle": "Séance",
+  "sessionDateAt": "{date} à {time}",
   "sessionCountdown": "Compte à rebours",
   "sessionStopwatch": "Chronomètre",
   "sessionCompleted": "Terminé",

--- a/citta/lib/l10n/app_gu.arb
+++ b/citta/lib/l10n/app_gu.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "સત્ર પૂર્ણ",
   "sessionTitle": "સત્ર",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "પૂર્ણ",

--- a/citta/lib/l10n/app_he.arb
+++ b/citta/lib/l10n/app_he.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "המפגש הסתיים",
   "sessionTitle": "מפגש",
+  "sessionDateAt": "{date} בשעה {time}",
   "sessionCountdown": "ספירה לאחור",
   "sessionStopwatch": "שעון עצר",
   "sessionCompleted": "הושלם",

--- a/citta/lib/l10n/app_hi.arb
+++ b/citta/lib/l10n/app_hi.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "सत्र पूर्ण",
   "sessionTitle": "सत्र",
+  "sessionDateAt": "{date} को {time}",
   "sessionCountdown": "काउंटडाउन",
   "sessionStopwatch": "स्टॉपवॉच",
   "sessionCompleted": "पूर्ण हुआ",

--- a/citta/lib/l10n/app_it.arb
+++ b/citta/lib/l10n/app_it.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "Sessione completata",
   "sessionTitle": "Sessione",
+  "sessionDateAt": "{date} alle {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "Completato",

--- a/citta/lib/l10n/app_ja.arb
+++ b/citta/lib/l10n/app_ja.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "セッション完了",
   "sessionTitle": "セッション",
+  "sessionDateAt": "{date} {time}",
   "sessionCountdown": "カウントダウン",
   "sessionStopwatch": "ストップウォッチ",
   "sessionCompleted": "完了",

--- a/citta/lib/l10n/app_kn.arb
+++ b/citta/lib/l10n/app_kn.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "ಸೆಷನ್ ಪೂರ್ಣ",
   "sessionTitle": "ಸೆಷನ್",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "ಕೌಂಟ್‌ಡೌನ್",
   "sessionStopwatch": "ಸ್ಟಾಪ್‌ವಾಚ್",
   "sessionCompleted": "ಪೂರ್ಣಗೊಂಡಿದೆ",

--- a/citta/lib/l10n/app_kok.arb
+++ b/citta/lib/l10n/app_kok.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "सेशन पूर्ण",
   "sessionTitle": "सेशन",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "पूर्ण",

--- a/citta/lib/l10n/app_localizations.dart
+++ b/citta/lib/l10n/app_localizations.dart
@@ -88,7 +88,7 @@ import 'app_localizations_zh.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -111,11 +111,11 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -145,7 +145,7 @@ abstract class AppLocalizations {
     Locale('tcy'),
     Locale('te'),
     Locale('ur'),
-    Locale('zh'),
+    Locale('zh')
   ];
 
   /// No description provided for @actionCancel.
@@ -718,6 +718,12 @@ abstract class AppLocalizations {
   /// **'Session'**
   String get sessionTitle;
 
+  /// No description provided for @sessionDateAt.
+  ///
+  /// In en, this message translates to:
+  /// **'{date} at {time}'**
+  String sessionDateAt(String date, String time);
+
   /// No description provided for @sessionCountdown.
   ///
   /// In en, this message translates to:
@@ -1012,34 +1018,34 @@ class _AppLocalizationsDelegate
 
   @override
   bool isSupported(Locale locale) => <String>[
-    'ar',
-    'as',
-    'bn',
-    'de',
-    'en',
-    'es',
-    'fr',
-    'gu',
-    'he',
-    'hi',
-    'it',
-    'ja',
-    'kn',
-    'kok',
-    'mai',
-    'ml',
-    'mr',
-    'or',
-    'pa',
-    'pt',
-    'ru',
-    'sa',
-    'ta',
-    'tcy',
-    'te',
-    'ur',
-    'zh',
-  ].contains(locale.languageCode);
+        'ar',
+        'as',
+        'bn',
+        'de',
+        'en',
+        'es',
+        'fr',
+        'gu',
+        'he',
+        'hi',
+        'it',
+        'ja',
+        'kn',
+        'kok',
+        'mai',
+        'ml',
+        'mr',
+        'or',
+        'pa',
+        'pt',
+        'ru',
+        'sa',
+        'ta',
+        'tcy',
+        'te',
+        'ur',
+        'zh'
+      ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -1105,9 +1111,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/citta/lib/l10n/app_localizations_ar.dart
+++ b/citta/lib/l10n/app_localizations_ar.dart
@@ -319,6 +319,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get sessionTitle => 'الجلسة';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date في $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_as.dart
+++ b/citta/lib/l10n/app_localizations_as.dart
@@ -320,6 +320,11 @@ class AppLocalizationsAs extends AppLocalizations {
   String get sessionTitle => 'অধিৱেশন';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_bn.dart
+++ b/citta/lib/l10n/app_localizations_bn.dart
@@ -319,6 +319,11 @@ class AppLocalizationsBn extends AppLocalizations {
   String get sessionTitle => 'সেশন';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_de.dart
+++ b/citta/lib/l10n/app_localizations_de.dart
@@ -321,6 +321,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get sessionTitle => 'Sitzung';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date um $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_en.dart
+++ b/citta/lib/l10n/app_localizations_en.dart
@@ -321,6 +321,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionTitle => 'Session';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date at $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_es.dart
+++ b/citta/lib/l10n/app_localizations_es.dart
@@ -320,6 +320,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get sessionTitle => 'Sesión';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date a las $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_fr.dart
+++ b/citta/lib/l10n/app_localizations_fr.dart
@@ -323,6 +323,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sessionTitle => 'Séance';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date à $time';
+  }
+
+  @override
   String get sessionCountdown => 'Compte à rebours';
 
   @override

--- a/citta/lib/l10n/app_localizations_gu.dart
+++ b/citta/lib/l10n/app_localizations_gu.dart
@@ -320,6 +320,11 @@ class AppLocalizationsGu extends AppLocalizations {
   String get sessionTitle => 'સત્ર';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_he.dart
+++ b/citta/lib/l10n/app_localizations_he.dart
@@ -321,6 +321,11 @@ class AppLocalizationsHe extends AppLocalizations {
   String get sessionTitle => 'מפגש';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date בשעה $time';
+  }
+
+  @override
   String get sessionCountdown => 'ספירה לאחור';
 
   @override

--- a/citta/lib/l10n/app_localizations_hi.dart
+++ b/citta/lib/l10n/app_localizations_hi.dart
@@ -321,6 +321,11 @@ class AppLocalizationsHi extends AppLocalizations {
   String get sessionTitle => 'सत्र';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date को $time';
+  }
+
+  @override
   String get sessionCountdown => 'काउंटडाउन';
 
   @override

--- a/citta/lib/l10n/app_localizations_it.dart
+++ b/citta/lib/l10n/app_localizations_it.dart
@@ -320,6 +320,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get sessionTitle => 'Sessione';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date alle $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_ja.dart
+++ b/citta/lib/l10n/app_localizations_ja.dart
@@ -312,6 +312,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get sessionTitle => 'セッション';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date $time';
+  }
+
+  @override
   String get sessionCountdown => 'カウントダウン';
 
   @override

--- a/citta/lib/l10n/app_localizations_kn.dart
+++ b/citta/lib/l10n/app_localizations_kn.dart
@@ -321,6 +321,11 @@ class AppLocalizationsKn extends AppLocalizations {
   String get sessionTitle => 'ಸೆಷನ್';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'ಕೌಂಟ್‌ಡೌನ್';
 
   @override

--- a/citta/lib/l10n/app_localizations_kok.dart
+++ b/citta/lib/l10n/app_localizations_kok.dart
@@ -320,6 +320,11 @@ class AppLocalizationsKok extends AppLocalizations {
   String get sessionTitle => 'सेशन';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_mai.dart
+++ b/citta/lib/l10n/app_localizations_mai.dart
@@ -320,6 +320,11 @@ class AppLocalizationsMai extends AppLocalizations {
   String get sessionTitle => 'सेशन';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_ml.dart
+++ b/citta/lib/l10n/app_localizations_ml.dart
@@ -320,6 +320,11 @@ class AppLocalizationsMl extends AppLocalizations {
   String get sessionTitle => 'സെഷൻ';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'കൗണ്ട്ഡൗൺ';
 
   @override

--- a/citta/lib/l10n/app_localizations_mr.dart
+++ b/citta/lib/l10n/app_localizations_mr.dart
@@ -321,6 +321,11 @@ class AppLocalizationsMr extends AppLocalizations {
   String get sessionTitle => 'सत्र';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'उलटगणती';
 
   @override

--- a/citta/lib/l10n/app_localizations_or.dart
+++ b/citta/lib/l10n/app_localizations_or.dart
@@ -320,6 +320,11 @@ class AppLocalizationsOr extends AppLocalizations {
   String get sessionTitle => 'ସ‌ଶନ';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_pa.dart
+++ b/citta/lib/l10n/app_localizations_pa.dart
@@ -319,6 +319,11 @@ class AppLocalizationsPa extends AppLocalizations {
   String get sessionTitle => 'ਸੈਸ਼ਨ';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date ਨੂੰ $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_pt.dart
+++ b/citta/lib/l10n/app_localizations_pt.dart
@@ -320,6 +320,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get sessionTitle => 'Sessão';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date às $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_ru.dart
+++ b/citta/lib/l10n/app_localizations_ru.dart
@@ -320,6 +320,11 @@ class AppLocalizationsRu extends AppLocalizations {
   String get sessionTitle => 'Сессия';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date в $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_sa.dart
+++ b/citta/lib/l10n/app_localizations_sa.dart
@@ -320,6 +320,11 @@ class AppLocalizationsSa extends AppLocalizations {
   String get sessionTitle => 'सत्रम्';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'गणना';
 
   @override

--- a/citta/lib/l10n/app_localizations_ta.dart
+++ b/citta/lib/l10n/app_localizations_ta.dart
@@ -322,6 +322,11 @@ class AppLocalizationsTa extends AppLocalizations {
   String get sessionTitle => 'அமர்வு';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'எண்ணிக்கை';
 
   @override

--- a/citta/lib/l10n/app_localizations_tcy.dart
+++ b/citta/lib/l10n/app_localizations_tcy.dart
@@ -320,6 +320,11 @@ class AppLocalizationsTcy extends AppLocalizations {
   String get sessionTitle => 'ಸೆಶನ್';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_te.dart
+++ b/citta/lib/l10n/app_localizations_te.dart
@@ -320,6 +320,11 @@ class AppLocalizationsTe extends AppLocalizations {
   String get sessionTitle => 'సెషన్';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date, $time';
+  }
+
+  @override
   String get sessionCountdown => 'కౌంట్‌డౌన్';
 
   @override

--- a/citta/lib/l10n/app_localizations_ur.dart
+++ b/citta/lib/l10n/app_localizations_ur.dart
@@ -320,6 +320,11 @@ class AppLocalizationsUr extends AppLocalizations {
   String get sessionTitle => 'سیشن';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date کو $time';
+  }
+
+  @override
   String get sessionCountdown => 'Countdown';
 
   @override

--- a/citta/lib/l10n/app_localizations_zh.dart
+++ b/citta/lib/l10n/app_localizations_zh.dart
@@ -312,6 +312,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get sessionTitle => '会话';
 
   @override
+  String sessionDateAt(String date, String time) {
+    return '$date $time';
+  }
+
+  @override
   String get sessionCountdown => '倒计时';
 
   @override

--- a/citta/lib/l10n/app_mai.arb
+++ b/citta/lib/l10n/app_mai.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "सेशन पूर्ण",
   "sessionTitle": "सेशन",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "पूर्ण",

--- a/citta/lib/l10n/app_ml.arb
+++ b/citta/lib/l10n/app_ml.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "സെഷൻ പൂർത്തിയായി",
   "sessionTitle": "സെഷൻ",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "കൗണ്ട്ഡൗൺ",
   "sessionStopwatch": "സ്റ്റോപ്‌വാച്ച്",
   "sessionCompleted": "പൂർത്തിയായി",

--- a/citta/lib/l10n/app_mr.arb
+++ b/citta/lib/l10n/app_mr.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "सत्र पूर्ण",
   "sessionTitle": "सत्र",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "उलटगणती",
   "sessionStopwatch": "स्टॉपवॉच",
   "sessionCompleted": "पूर्ण",

--- a/citta/lib/l10n/app_or.arb
+++ b/citta/lib/l10n/app_or.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "ସ‌ଶନ ସ‌ମ୍ପୂର୍ଣ",
   "sessionTitle": "ସ‌ଶନ",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "ସ‌ମ୍ପୂର୍ଣ",

--- a/citta/lib/l10n/app_pa.arb
+++ b/citta/lib/l10n/app_pa.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "ਸੈਸ਼ਨ ਪੂਰਾ",
   "sessionTitle": "ਸੈਸ਼ਨ",
+  "sessionDateAt": "{date} ਨੂੰ {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "ਪੂਰਾ",

--- a/citta/lib/l10n/app_pt.arb
+++ b/citta/lib/l10n/app_pt.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "Sessão concluída",
   "sessionTitle": "Sessão",
+  "sessionDateAt": "{date} às {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "Concluído",

--- a/citta/lib/l10n/app_ru.arb
+++ b/citta/lib/l10n/app_ru.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "Сессия завершена",
   "sessionTitle": "Сессия",
+  "sessionDateAt": "{date} в {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "Завершено",

--- a/citta/lib/l10n/app_sa.arb
+++ b/citta/lib/l10n/app_sa.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "सत्रं पूर्णम्",
   "sessionTitle": "सत्रम्",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "गणना",
   "sessionStopwatch": "कालमापकम्",
   "sessionCompleted": "पूर्णम्",

--- a/citta/lib/l10n/app_ta.arb
+++ b/citta/lib/l10n/app_ta.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "அமர்வு முடிந்தது",
   "sessionTitle": "அமர்வு",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "எண்ணிக்கை",
   "sessionStopwatch": "நிறுத்த கடிகாரம்",
   "sessionCompleted": "முடிந்தது",

--- a/citta/lib/l10n/app_tcy.arb
+++ b/citta/lib/l10n/app_tcy.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "ಸೆಶನ್ ಮುಗಿಪ್ಪಿ",
   "sessionTitle": "ಸೆಶನ್",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "ಮುಗಿಪ್ಪಿ",

--- a/citta/lib/l10n/app_te.arb
+++ b/citta/lib/l10n/app_te.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "సెషన్ పూర్తి",
   "sessionTitle": "సెషన్",
+  "sessionDateAt": "{date}, {time}",
   "sessionCountdown": "కౌంట్‌డౌన్",
   "sessionStopwatch": "స్టాప్‌వాచ్",
   "sessionCompleted": "పూర్తయింది",

--- a/citta/lib/l10n/app_ur.arb
+++ b/citta/lib/l10n/app_ur.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "سیشن مکمل",
   "sessionTitle": "سیشن",
+  "sessionDateAt": "{date} کو {time}",
   "sessionCountdown": "Countdown",
   "sessionStopwatch": "Stopwatch",
   "sessionCompleted": "مکمل",

--- a/citta/lib/l10n/app_zh.arb
+++ b/citta/lib/l10n/app_zh.arb
@@ -131,6 +131,7 @@
 
   "sessionComplete": "会话完成",
   "sessionTitle": "会话",
+  "sessionDateAt": "{date} {time}",
   "sessionCountdown": "倒计时",
   "sessionStopwatch": "秒表",
   "sessionCompleted": "已完成",

--- a/citta/lib/screens/history_screen.dart
+++ b/citta/lib/screens/history_screen.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:citta/l10n/app_localizations.dart';
-import 'package:citta/l10n/intl_locale.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import '../providers/app_state.dart';
 import '../models/session_model.dart';
 import '../theme/app_theme.dart';
+import '../utils/formatters.dart';
 import 'session_detail_screen.dart';
 
 class HistoryScreen extends StatefulWidget {
@@ -200,11 +199,10 @@ class _HistoryScreenState extends State<HistoryScreen> {
   Widget _buildSessionCard(
       BuildContext context, SessionModel session, AppLocalizations l10n) {
     final date = session.date.toLocal();
-    final localeStr = safeIntlLocale(Localizations.localeOf(context).toString());
-    final dateStr = DateFormat('MMM d, y', localeStr).format(date);
-    final timeStr =
-        '${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
-    final duration = _formatDuration(session.duration);
+    final localeStr = currentLocaleStr(context);
+    final dateStr = formatSessionDate(date, localeStr);
+    final timeStr = formatSessionTime(date, localeStr);
+    final duration = formatDuration(session.duration);
     final isSelected = _selectedSessionIds.contains(session.id);
     final colorScheme = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
@@ -332,12 +330,5 @@ class _HistoryScreenState extends State<HistoryScreen> {
         ],
       ),
     );
-  }
-
-  String _formatDuration(int seconds) {
-    final mins = seconds ~/ 60;
-    final secs = seconds % 60;
-    if (mins == 0) return '${secs}s';
-    return secs > 0 ? '${mins}m ${secs}s' : '${mins}m';
   }
 }

--- a/citta/lib/screens/notes_screen.dart
+++ b/citta/lib/screens/notes_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../models/session_model.dart';
 import '../providers/app_state.dart';
 import '../theme/app_theme.dart';
+import '../utils/formatters.dart';
 
 class NotesScreen extends StatefulWidget {
   final SessionModel session;
@@ -58,13 +59,6 @@ class _NotesScreenState extends State<NotesScreen> {
     }
   }
 
-  String _formatDuration(int seconds) {
-    final mins = seconds ~/ 60;
-    final secs = seconds % 60;
-    if (mins == 0) return '${secs}s';
-    return secs > 0 ? '${mins}m ${secs}s' : '${mins}m';
-  }
-
   @override
   void dispose() {
     _notesController.dispose();
@@ -108,7 +102,7 @@ class _NotesScreenState extends State<NotesScreen> {
                         color: AppColors.primary, size: 20),
                     const SizedBox(width: 8),
                     Text(
-                      _formatDuration(widget.session.duration),
+                      formatDuration(widget.session.duration),
                       style: Theme.of(context).textTheme.titleLarge,
                     ),
                     if (widget.session.completedFully) ...[

--- a/citta/lib/screens/session_complete_screen.dart
+++ b/citta/lib/screens/session_complete_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:citta/l10n/app_localizations.dart';
 import '../models/session_model.dart';
 import '../theme/app_theme.dart';
+import '../utils/formatters.dart';
 import 'notes_screen.dart';
 
 class SessionCompleteScreen extends StatefulWidget {
@@ -29,13 +30,6 @@ class _SessionCompleteScreenState extends State<SessionCompleteScreen> {
     );
   }
 
-  String _formatDuration(int seconds) {
-    final mins = seconds ~/ 60;
-    final secs = seconds % 60;
-    if (mins == 0) return '${secs}s';
-    return secs > 0 ? '${mins}m ${secs}s' : '${mins}m';
-  }
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -59,7 +53,7 @@ class _SessionCompleteScreenState extends State<SessionCompleteScreen> {
               ),
               const SizedBox(height: 12),
               Text(
-                _formatDuration(widget.session.duration),
+                formatDuration(widget.session.duration),
                 style: Theme.of(context).textTheme.titleLarge?.copyWith(
                       color: AppColors.textSecondary,
                     ),

--- a/citta/lib/screens/session_detail_screen.dart
+++ b/citta/lib/screens/session_detail_screen.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:citta/l10n/app_localizations.dart';
-import 'package:citta/l10n/intl_locale.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
-import 'package:intl/intl.dart';
 import '../models/session_model.dart';
 import '../theme/app_theme.dart';
+import '../utils/formatters.dart';
 
 class SessionDetailScreen extends StatelessWidget {
   final SessionModel session;
@@ -14,10 +13,10 @@ class SessionDetailScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final localeStr = safeIntlLocale(Localizations.localeOf(context).toString());
+    final localeStr = currentLocaleStr(context);
     final date = session.date.toLocal();
-    final dateStr =
-        '${DateFormat('MMM d, y', localeStr).format(date)} at ${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
+    final dateStr = l10n.sessionDateAt(
+        formatSessionDate(date, localeStr), formatSessionTime(date, localeStr));
 
     final colorScheme = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
@@ -50,7 +49,8 @@ class SessionDetailScreen extends StatelessWidget {
               child: Column(
                 children: [
                   Text(
-                    _formatDuration(session.duration),
+                    formatDuration(session.duration,
+                        style: DurationDisplayStyle.full),
                     style: Theme.of(context).textTheme.headlineLarge,
                   ),
                   const SizedBox(height: 4),
@@ -146,16 +146,5 @@ class SessionDetailScreen extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  String _formatDuration(int seconds) {
-    final hours = seconds ~/ 3600;
-    final mins = (seconds % 3600) ~/ 60;
-    final secs = seconds % 60;
-    if (hours > 0) {
-      return '${hours}h ${mins}m';
-    }
-    if (mins == 0) return '${secs}s';
-    return secs > 0 ? '${mins}m ${secs}s' : '${mins}m';
   }
 }

--- a/citta/lib/screens/stats_screen.dart
+++ b/citta/lib/screens/stats_screen.dart
@@ -5,6 +5,7 @@ import '../models/session_model.dart';
 import '../providers/app_state.dart';
 import '../services/stats_service.dart';
 import '../theme/app_theme.dart';
+import '../utils/formatters.dart';
 import '../widgets/calendar_view.dart';
 
 class StatsScreen extends StatelessWidget {
@@ -87,7 +88,8 @@ class StatsScreen extends StatelessWidget {
                     icon: Icons.schedule,
                     iconColor: AppColors.accent,
                     label: l10n.statsAverage,
-                    value: _formatDuration(stats.averageDurationSeconds),
+                    value: formatDuration(stats.averageDurationSeconds,
+                        style: DurationDisplayStyle.compact),
                     unit: '',
                   ),
                 ),
@@ -102,12 +104,6 @@ class StatsScreen extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  String _formatDuration(int seconds) {
-    if (seconds == 0) return '0m';
-    final mins = seconds ~/ 60;
-    return '${mins}m';
   }
 }
 

--- a/citta/lib/utils/formatters.dart
+++ b/citta/lib/utils/formatters.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/widgets.dart' show BuildContext, Localizations;
+import 'package:intl/intl.dart';
+import '../l10n/intl_locale.dart';
+
+/// Display variants for [formatDuration].
+enum DurationDisplayStyle {
+  /// Minutes only, e.g. `5m`. Used where space is tight (stats tiles).
+  compact,
+
+  /// Minutes and seconds, e.g. `5m 30s`, falling back to `45s` under a
+  /// minute. Does not roll over into hours.
+  short,
+
+  /// Same as [short], but rolls over into hours as `1h 5m` once the
+  /// duration reaches an hour.
+  full,
+}
+
+/// Formats a duration given in [totalSeconds] according to [style].
+String formatDuration(
+  int totalSeconds, {
+  DurationDisplayStyle style = DurationDisplayStyle.short,
+}) {
+  if (style == DurationDisplayStyle.compact) {
+    return '${totalSeconds ~/ 60}m';
+  }
+
+  final minutes = totalSeconds ~/ 60;
+  final seconds = totalSeconds % 60;
+
+  if (style == DurationDisplayStyle.full) {
+    final hours = totalSeconds ~/ 3600;
+    if (hours > 0) {
+      return '${hours}h ${(totalSeconds % 3600) ~/ 60}m';
+    }
+  }
+
+  if (minutes == 0) return '${seconds}s';
+  return seconds > 0 ? '${minutes}m ${seconds}s' : '${minutes}m';
+}
+
+/// Resolves the current locale from [context], falling back to `en` for
+/// locales the intl package has no data for.
+String currentLocaleStr(BuildContext context) =>
+    safeIntlLocale(Localizations.localeOf(context).toString());
+
+/// Formats [date] as a locale-appropriate abbreviated date, e.g. `Mar 5,
+/// 2024` for `en` or `5. März 2024` for `de`.
+String formatSessionDate(DateTime date, String localeStr) =>
+    DateFormat.yMMMd(localeStr).format(date);
+
+/// Formats [date]'s time of day using the locale's conventional 12h/24h
+/// clock, e.g. `9:05 AM` for `en` or `09:05` for `de`.
+String formatSessionTime(DateTime date, String localeStr) =>
+    DateFormat.jm(localeStr).format(date);
+
+/// Formats [date] as `MMMM y`, e.g. `March 2024`.
+String formatMonthYear(DateTime date, String localeStr) =>
+    DateFormat('MMMM y', localeStr).format(date);
+
+/// Formats [date]'s weekday abbreviation, e.g. `Mon`.
+String formatWeekdayShort(DateTime date, String localeStr) =>
+    DateFormat('E', localeStr).format(date);

--- a/citta/lib/widgets/calendar_view.dart
+++ b/citta/lib/widgets/calendar_view.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
-import '../l10n/intl_locale.dart';
 import '../models/session_model.dart';
 import '../services/stats_service.dart';
 import '../theme/app_theme.dart';
+import '../utils/formatters.dart';
 
 class CalendarView extends StatefulWidget {
   final List<SessionModel> sessions;
@@ -37,7 +36,7 @@ class _CalendarViewState extends State<CalendarView> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final newLocale = safeIntlLocale(Localizations.localeOf(context).toString());
+    final newLocale = currentLocaleStr(context);
     if (newLocale == _localeStr) return;
     _localeStr = newLocale;
     _updateMonthName();
@@ -45,14 +44,16 @@ class _CalendarViewState extends State<CalendarView> {
   }
 
   void _updateMonthName() {
-    _monthName = DateFormat('MMMM y', _localeStr)
-        .format(DateTime(_currentMonth.year, _currentMonth.month));
+    _monthName = formatMonthYear(
+      DateTime(_currentMonth.year, _currentMonth.month),
+      _localeStr,
+    );
   }
 
   void _buildWeekdayHeaders() {
     _weekdayHeaders = List.generate(
       7,
-      (i) => DateFormat('E', _localeStr).format(DateTime(2024, 1, i + 1)),
+      (i) => formatWeekdayShort(DateTime(2024, 1, i + 1), _localeStr),
     );
   }
 

--- a/citta/test/utils/formatters_test.dart
+++ b/citta/test/utils/formatters_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:citta/l10n/fallback_localizations_delegate.dart';
+import 'package:citta/utils/formatters.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('en');
+    await initializeDateFormatting('de');
+    await initializeDateFormatting('fr');
+  });
+
+  group('formatDuration - short style (default)', () {
+    test('zero seconds', () {
+      expect(formatDuration(0), equals('0s'));
+    });
+
+    test('sub-minute duration', () {
+      expect(formatDuration(45), equals('45s'));
+    });
+
+    test('exact minutes', () {
+      expect(formatDuration(60), equals('1m'));
+    });
+
+    test('minutes and seconds', () {
+      expect(formatDuration(90), equals('1m 30s'));
+    });
+
+    test('does not roll over into hours', () {
+      expect(formatDuration(3661), equals('61m 1s'));
+    });
+  });
+
+  group('formatDuration - full style', () {
+    const style = DurationDisplayStyle.full;
+
+    test('zero seconds', () {
+      expect(formatDuration(0, style: style), equals('0s'));
+    });
+
+    test('sub-minute duration falls back to short logic', () {
+      expect(formatDuration(45, style: style), equals('45s'));
+    });
+
+    test('minutes and seconds falls back to short logic', () {
+      expect(formatDuration(90, style: style), equals('1m 30s'));
+    });
+
+    test('exact hour rolls into hours+minutes', () {
+      expect(formatDuration(3600, style: style), equals('1h 0m'));
+    });
+
+    test('hour with partial minutes', () {
+      expect(formatDuration(3660, style: style), equals('1h 1m'));
+    });
+  });
+
+  group('formatDuration - compact style', () {
+    const style = DurationDisplayStyle.compact;
+
+    test('zero seconds', () {
+      expect(formatDuration(0, style: style), equals('0m'));
+    });
+
+    test('sub-minute rounds down to 0m', () {
+      expect(formatDuration(45, style: style), equals('0m'));
+    });
+
+    test('exact minutes', () {
+      expect(formatDuration(125, style: style), equals('2m'));
+    });
+
+    test('past an hour stays in minutes', () {
+      expect(formatDuration(3661, style: style), equals('61m'));
+    });
+  });
+
+  group('formatSessionDate', () {
+    test('formats month, day, year for en', () {
+      final date = DateTime(2024, 3, 5, 9, 5);
+      expect(formatSessionDate(date, 'en'), equals('Mar 5, 2024'));
+    });
+
+    test('uses locale-appropriate order and month name for de', () {
+      final date = DateTime(2024, 3, 5, 9, 5);
+      expect(formatSessionDate(date, 'de'), equals('5. März 2024'));
+    });
+
+    test('uses locale-appropriate order and month name for fr', () {
+      final date = DateTime(2024, 3, 5, 9, 5);
+      expect(formatSessionDate(date, 'fr'), equals('5 mars 2024'));
+    });
+  });
+
+  group('formatSessionTime', () {
+    test('en uses a 12-hour clock with AM/PM', () {
+      final date = DateTime(2024, 3, 5, 9, 5);
+      // intl separates the AM/PM marker with a narrow no-break space (U+202F).
+      expect(formatSessionTime(date, 'en'), equals('9:05 AM'));
+    });
+
+    test('en formats late night time with PM', () {
+      final date = DateTime(2024, 3, 5, 23, 59);
+      expect(formatSessionTime(date, 'en'), equals('11:59 PM'));
+    });
+
+    test('de uses a zero-padded 24-hour clock', () {
+      final date = DateTime(2024, 3, 5, 9, 5);
+      expect(formatSessionTime(date, 'de'), equals('09:05'));
+    });
+
+    test('de formats late night time on a 24-hour clock', () {
+      final date = DateTime(2024, 3, 5, 23, 59);
+      expect(formatSessionTime(date, 'de'), equals('23:59'));
+    });
+  });
+
+  group('formatMonthYear', () {
+    test('formats full month name and year', () {
+      final date = DateTime(2024, 3, 1);
+      expect(formatMonthYear(date, 'en'), equals('March 2024'));
+    });
+  });
+
+  group('formatWeekdayShort', () {
+    test('formats abbreviated weekday name', () {
+      // 2024-01-01 is a Monday.
+      final date = DateTime(2024, 1, 1);
+      expect(formatWeekdayShort(date, 'en'), equals('Mon'));
+    });
+  });
+
+  group('currentLocaleStr', () {
+    testWidgets('falls back to en for locales intl has no data for', (tester) async {
+      late String result;
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('sa'),
+          localizationsDelegates: const [
+            FallbackMaterialLocalizationsDelegate(),
+            GlobalWidgetsLocalizations.delegate,
+            FallbackCupertinoLocalizationsDelegate(),
+          ],
+          supportedLocales: const [Locale('sa'), Locale('en')],
+          home: Builder(
+            builder: (context) {
+              result = currentLocaleStr(context);
+              return const Placeholder();
+            },
+          ),
+        ),
+      );
+      expect(result, equals('en'));
+    });
+
+    testWidgets('passes through a locale intl supports', (tester) async {
+      late String result;
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: const [
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [Locale('en')],
+          home: Builder(
+            builder: (context) {
+              result = currentLocaleStr(context);
+              return const Placeholder();
+            },
+          ),
+        ),
+      );
+      expect(result, equals('en'));
+    });
+  });
+}

--- a/docs/codex-review
+++ b/docs/codex-review
@@ -1,0 +1,38 @@
+# Codex Review
+
+## Scope
+
+Review of the current local changes for GitHub issue `#15`: `Extract shared duration and date formatter utilities`.
+
+Issue requirement reviewed against:
+
+- Extract duplicated duration formatting into a shared utility
+- Extract shared date/time helpers
+- Keep UI output consistent and improve localization/locale handling
+
+## Findings
+
+No code-review findings in the current branch state.
+
+The earlier locale-formatting gap appears closed. [formatters.dart](/home/harsha/workspace/Citta/citta/lib/utils/formatters.dart:49) now uses `DateFormat.yMMMd(localeStr)` for locale-appropriate abbreviated dates, and [formatters.dart](/home/harsha/workspace/Citta/citta/lib/utils/formatters.dart:54) uses `DateFormat.jm(localeStr)` so time formatting follows the locale’s conventional 12h/24h presentation. The updated wiring in [session_detail_screen.dart](/home/harsha/workspace/Citta/citta/lib/screens/session_detail_screen.dart:18) and [history_screen.dart](/home/harsha/workspace/Citta/citta/lib/screens/history_screen.dart:203) passes the locale through consistently, and the added regression coverage in [formatters_test.dart](/home/harsha/workspace/Citta/citta/test/utils/formatters_test.dart:81) and [formatters_test.dart](/home/harsha/workspace/Citta/citta/test/utils/formatters_test.dart:98) now checks both English and non-English date/time behavior.
+
+## Verification
+
+- Reviewed issue `#15` via `gh issue view 15 --json number,title,body,state,url`
+- Inspected the local diff in:
+  - `citta/lib/utils/formatters.dart`
+  - `citta/test/utils/formatters_test.dart`
+  - `citta/lib/screens/history_screen.dart`
+  - `citta/lib/screens/notes_screen.dart`
+  - `citta/lib/screens/session_complete_screen.dart`
+  - `citta/lib/screens/session_detail_screen.dart`
+  - `citta/lib/screens/stats_screen.dart`
+  - `citta/lib/widgets/calendar_view.dart`
+  - generated `citta/lib/l10n/*` changes related to `sessionDateAt`
+- Searched formatter usage and remaining date/time formatting call sites with `rg -n "String _formatDuration|DateFormat\\(|padLeft\\(2, '0'\\)|formatSessionTime\\(|formatSessionDate\\(|currentLocaleStr\\(" citta/lib citta/test`
+- Ran `/home/harsha/flutter/flutter/bin/flutter test test/utils/formatters_test.dart`
+  - Result: passes
+
+## Summary
+
+No findings on the current revision. The shared formatter utility now centralizes the duplicated logic without preserving the earlier locale-formatting bug, and the targeted formatter tests pass.


### PR DESCRIPTION
## Summary
- Consolidates five duplicated `_formatDuration()` implementations and repeated inline `DateFormat`/`padLeft` date-time construction across `history_screen.dart`, `notes_screen.dart`, `session_complete_screen.dart`, `session_detail_screen.dart`, `stats_screen.dart`, and `calendar_view.dart` into a single `lib/utils/formatters.dart`.
- Fixes a codex-review finding on the initial extraction: the session date/time combiner no longer hardcodes the English word "at" — it's now routed through a new `sessionDateAt` localization key (translated for the app's supported locales).
- Fixes a second codex-review finding: date/time formatting now uses locale-aware `DateFormat.yMMMd`/`.jm` skeletons instead of a fixed English-style pattern, so the 12h/24h clock convention correctly follows each locale (e.g. `en` → "9:05 AM", `de`/`fr`/`ja` → "09:05").

Closes #15

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — full suite passes (309 tests)
- [x] New unit tests in `test/utils/formatters_test.dart` cover all `DurationDisplayStyle` variants and locale-aware date/time formatting (en/de/fr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)