### PR TITLE
Normalize background music config storage

### DIFF
--- a/citta/lib/screens/settings/audio_picker.dart
+++ b/citta/lib/screens/settings/audio_picker.dart
@@ -1,0 +1,11 @@
+import 'package:file_picker/file_picker.dart';
+
+/// Opens the OS file picker restricted to audio files and returns the
+/// selected file as a `custom:<path>` selection string — the same
+/// convention used for bell sounds — or `null` if the user cancelled or the
+/// picker returned no usable path.
+Future<String?> pickCustomAudioSelection() async {
+  final result = await FilePicker.platform.pickFiles(type: FileType.audio);
+  final path = result?.files.single.path;
+  return path == null ? null : 'custom:$path';
+}

--- a/citta/lib/screens/settings/bells_section.dart
+++ b/citta/lib/screens/settings/bells_section.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:provider/provider.dart';
 import 'package:citta/l10n/app_localizations.dart';
 import '../../providers/app_state.dart';
 import '../../services/audio_service.dart';
 import '../../theme/app_theme.dart';
+import 'audio_picker.dart';
 import 'settings_widgets.dart';
 
 String bellDisplayName(String bellId) {
@@ -155,12 +155,8 @@ class BellsSection extends StatelessWidget {
           SimpleDialogOption(
             onPressed: () async {
               Navigator.pop(context);
-              final result = await FilePicker.platform.pickFiles(
-                type: FileType.audio,
-              );
-              if (result != null && result.files.single.path != null) {
-                onSelect('custom:${result.files.single.path}');
-              }
+              final selection = await pickCustomAudioSelection();
+              if (selection != null) onSelect(selection);
             },
             child: Row(
               children: [

--- a/citta/lib/screens/settings/bg_music_section.dart
+++ b/citta/lib/screens/settings/bg_music_section.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:provider/provider.dart';
 import 'package:citta/l10n/app_localizations.dart';
 import '../../providers/app_state.dart';
 import '../../theme/app_theme.dart';
+import 'audio_picker.dart';
 import 'settings_widgets.dart';
 
 class BgMusicSection extends StatelessWidget {
@@ -38,10 +38,10 @@ class BgMusicSection extends StatelessWidget {
 
   Future<void> _pickBackgroundMusic(
       BuildContext context, AppState appState) async {
-    final result = await FilePicker.platform.pickFiles(type: FileType.audio);
-    if (result != null && result.files.single.path != null) {
-      appState.updateConfig(appState.config
-          .copyWith(backgroundMusic: result.files.single.path));
+    final selection = await pickCustomAudioSelection();
+    if (selection != null) {
+      appState.updateConfig(
+          appState.config.copyWith(backgroundMusic: selection));
     }
   }
 }

--- a/citta/lib/services/audio_service.dart
+++ b/citta/lib/services/audio_service.dart
@@ -214,21 +214,43 @@ class AudioService {
     }
   }
 
+  /// Resolves a `bundled:<name>` / `custom:<path>` selection id to a
+  /// concrete playable source — the single place that decodes this
+  /// convention, shared by bell and background-music playback.
+  ///
+  /// Set [allowBundled] to false for callers (background music) that don't
+  /// support bundled options, so a string that happens to start with
+  /// `bundled:` is treated as a raw/custom path instead. Set [allowRawPath]
+  /// for callers that must also accept legacy configs saved before the
+  /// `custom:` prefix convention existed. Returns null when the id names an
+  /// unknown bundled sound, or an unrecognized id with [allowRawPath] false
+  /// (e.g. "none").
+  ({bool isAsset, String path})? _resolveSource(
+    String id, {
+    bool allowBundled = true,
+    bool allowRawPath = false,
+  }) {
+    if (allowBundled && id.startsWith('bundled:')) {
+      final assetPath = bundledSounds[id.substring(8)];
+      return assetPath == null ? null : (isAsset: true, path: assetPath);
+    }
+    if (id.startsWith('custom:')) {
+      return (isAsset: false, path: id.substring(7));
+    }
+    return allowRawPath ? (isAsset: false, path: id) : null;
+  }
+
   /// Play a bell sound identified by its config string (e.g., "bundled:tibetan_bowl" or "custom:/path/to/file.mp3")
   /// Retries once on failure — ExoPlayer bypass mode can fail on first attempt on some Android versions.
   Future<void> playBell(String bellId, {bool isRetry = false}) async {
     try {
-      if (bellId.startsWith('bundled:')) {
-        final name = bellId.substring(8);
-        final assetPath = bundledSounds[name];
-        if (assetPath != null) {
-          await _bellPlayer.setAsset(assetPath);
-          await _bellPlayer.seek(const Duration(milliseconds: 1));
-          await _bellPlayer.play();
+      final source = _resolveSource(bellId);
+      if (source != null) {
+        if (source.isAsset) {
+          await _bellPlayer.setAsset(source.path);
+        } else {
+          await _bellPlayer.setFilePath(source.path);
         }
-      } else if (bellId.startsWith('custom:')) {
-        final path = bellId.substring(7);
-        await _bellPlayer.setFilePath(path);
         await _bellPlayer.seek(const Duration(milliseconds: 1));
         await _bellPlayer.play();
       }
@@ -251,15 +273,12 @@ class AudioService {
   /// this is a best-effort warm-up only.
   Future<void> warmUp(String bellId) async {
     try {
-      if (bellId.startsWith('bundled:')) {
-        final name = bellId.substring(8);
-        final assetPath = bundledSounds[name];
-        if (assetPath == null) return;
-        await _bellPlayer.setAsset(assetPath);
-      } else if (bellId.startsWith('custom:')) {
-        await _bellPlayer.setFilePath(bellId.substring(7));
+      final source = _resolveSource(bellId);
+      if (source == null) return;
+      if (source.isAsset) {
+        await _bellPlayer.setAsset(source.path);
       } else {
-        return;
+        await _bellPlayer.setFilePath(source.path);
       }
       await _bellPlayer.setVolume(0);
       await _bellPlayer.seek(const Duration(milliseconds: 1));
@@ -272,13 +291,16 @@ class AudioService {
   }
 
   /// Start background music playback (looping).
+  ///
+  /// [path] follows the same `custom:<path>` convention as bell IDs (see
+  /// [playBell]) — background music has no bundled options, so this is the
+  /// only prefix in use. Raw, unprefixed paths are still accepted so configs
+  /// saved before this convention was introduced keep working.
   Future<void> startBackgroundMusic(String path) async {
     try {
-      if (path.startsWith('custom:')) {
-        await _musicPlayer.setFilePath(path.substring(7));
-      } else {
-        await _musicPlayer.setFilePath(path);
-      }
+      final source =
+          _resolveSource(path, allowBundled: false, allowRawPath: true)!;
+      await _musicPlayer.setFilePath(source.path);
       await _musicPlayer.setLoopMode(LoopMode.all);
       await _musicPlayer.setVolume(0.3);
       await _musicPlayer.play();

--- a/citta/pubspec.yaml
+++ b/citta/pubspec.yaml
@@ -28,6 +28,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^3.0.1
   flutter_launcher_icons: ^0.14.3
+  plugin_platform_interface: ^2.1.8
 
 flutter_launcher_icons:
   android: true

--- a/citta/test/screens/settings/settings_sections_test.dart
+++ b/citta/test/screens/settings/settings_sections_test.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:audio_session/audio_session.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:just_audio/just_audio.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:provider/provider.dart';
 
 import 'package:citta/l10n/app_localizations.dart';
@@ -14,6 +16,7 @@ import 'package:citta/screens/settings/profile_section.dart';
 import 'package:citta/screens/settings/appearance_section.dart';
 import 'package:citta/screens/settings/timer_section.dart';
 import 'package:citta/screens/settings/bells_section.dart';
+import 'package:citta/screens/settings/bg_music_section.dart';
 import 'package:citta/screens/settings/tags_section.dart';
 import 'package:citta/screens/settings/data_section.dart';
 import 'package:citta/screens/settings/settings_widgets.dart';
@@ -42,6 +45,34 @@ class _FakeAudioSession implements AudioSessionBase {
   @override Future<void> configure(AudioSessionConfiguration _) async {}
   @override Stream<AudioInterruptionEvent> get interruptionEventStream =>
       const Stream.empty();
+}
+
+// Stubs FilePicker.platform so tests can simulate a user picking a file
+// without touching the real OS file picker.
+class _FakeFilePicker extends FilePicker with MockPlatformInterfaceMixin {
+  _FakeFilePicker(this._resultPath);
+  final String? _resultPath;
+
+  @override
+  Future<FilePickerResult?> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    bool allowCompression = true,
+    int compressionQuality = 30,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+  }) async {
+    if (_resultPath == null) return null;
+    return FilePickerResult([
+      PlatformFile(path: _resultPath, name: 'music.mp3', size: 0),
+    ]);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -357,6 +388,75 @@ void main() {
       await tester.pumpWidget(_wrap(appState, const DataSection()));
       await tester.pump();
       expect(find.byType(SettingsTile), findsNWidgets(2));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // BgMusicSection
+  // ---------------------------------------------------------------------------
+
+  group('BgMusicSection – picking a file', () {
+    late Directory tmpDir;
+    late AppState appState;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('citta_settings_test_');
+      appState = await _makeAndInit(tmpDir.path);
+      FilePicker.platform = _FakeFilePicker('/storage/music/track.mp3');
+    });
+    tearDown(() => tmpDir.deleteSync(recursive: true));
+
+    testWidgets('stores the picked path with a custom: prefix',
+        (tester) async {
+      await tester.pumpWidget(_wrap(appState, const BgMusicSection()));
+      await tester.pump();
+      await tester.tap(find.byType(SettingsTile));
+      await tester.pumpAndSettle();
+      expect(appState.config.backgroundMusic,
+          equals('custom:/storage/music/track.mp3'));
+    });
+  });
+
+  group('BgMusicSection – cancelling the file picker', () {
+    late Directory tmpDir;
+    late AppState appState;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('citta_settings_test_');
+      appState = await _makeAndInit(tmpDir.path);
+      FilePicker.platform = _FakeFilePicker(null);
+    });
+    tearDown(() => tmpDir.deleteSync(recursive: true));
+
+    testWidgets('leaves backgroundMusic unset when the picker returns null',
+        (tester) async {
+      await tester.pumpWidget(_wrap(appState, const BgMusicSection()));
+      await tester.pump();
+      await tester.tap(find.byType(SettingsTile));
+      await tester.pumpAndSettle();
+      expect(appState.config.backgroundMusic, isNull);
+    });
+  });
+
+  group('BgMusicSection – legacy raw-path config', () {
+    late Directory tmpDir;
+    late AppState appState;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('citta_settings_test_');
+      appState = await _makeAndInit(tmpDir.path,
+          initialConfig: ConfigModel(backgroundMusic: '/legacy/music.mp3'));
+    });
+    tearDown(() => tmpDir.deleteSync(recursive: true));
+
+    testWidgets('renders as selected and can be removed', (tester) async {
+      await tester.pumpWidget(_wrap(appState, const BgMusicSection()));
+      await tester.pump();
+      expect(find.byIcon(Icons.clear), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pump();
+      expect(appState.config.backgroundMusic, isNull);
     });
   });
 }

--- a/docs/codex-review
+++ b/docs/codex-review
@@ -2,37 +2,34 @@
 
 ## Scope
 
-Review of the current local changes for GitHub issue `#15`: `Extract shared duration and date formatter utilities`.
+Review of the current local changes for GitHub issue `#16`: `Normalize background music config storage format`.
 
 Issue requirement reviewed against:
 
-- Extract duplicated duration formatting into a shared utility
-- Extract shared date/time helpers
-- Keep UI output consistent and improve localization/locale handling
+- Persist background music using one consistent convention
+- Keep backward compatibility for already-saved raw-path configs
+- Avoid regressions in bell sound selection and playback
 
 ## Findings
 
 No code-review findings in the current branch state.
 
-The earlier locale-formatting gap appears closed. [formatters.dart](/home/harsha/workspace/Citta/citta/lib/utils/formatters.dart:49) now uses `DateFormat.yMMMd(localeStr)` for locale-appropriate abbreviated dates, and [formatters.dart](/home/harsha/workspace/Citta/citta/lib/utils/formatters.dart:54) uses `DateFormat.jm(localeStr)` so time formatting follows the locale’s conventional 12h/24h presentation. The updated wiring in [session_detail_screen.dart](/home/harsha/workspace/Citta/citta/lib/screens/session_detail_screen.dart:18) and [history_screen.dart](/home/harsha/workspace/Citta/citta/lib/screens/history_screen.dart:203) passes the locale through consistently, and the added regression coverage in [formatters_test.dart](/home/harsha/workspace/Citta/citta/test/utils/formatters_test.dart:81) and [formatters_test.dart](/home/harsha/workspace/Citta/citta/test/utils/formatters_test.dart:98) now checks both English and non-English date/time behavior.
-
 ## Verification
 
-- Reviewed issue `#15` via `gh issue view 15 --json number,title,body,state,url`
+- Reviewed issue `#16` via `gh issue view 16 --json number,title,body,state,url`
 - Inspected the local diff in:
-  - `citta/lib/utils/formatters.dart`
-  - `citta/test/utils/formatters_test.dart`
-  - `citta/lib/screens/history_screen.dart`
-  - `citta/lib/screens/notes_screen.dart`
-  - `citta/lib/screens/session_complete_screen.dart`
-  - `citta/lib/screens/session_detail_screen.dart`
-  - `citta/lib/screens/stats_screen.dart`
-  - `citta/lib/widgets/calendar_view.dart`
-  - generated `citta/lib/l10n/*` changes related to `sessionDateAt`
-- Searched formatter usage and remaining date/time formatting call sites with `rg -n "String _formatDuration|DateFormat\\(|padLeft\\(2, '0'\\)|formatSessionTime\\(|formatSessionDate\\(|currentLocaleStr\\(" citta/lib citta/test`
-- Ran `/home/harsha/flutter/flutter/bin/flutter test test/utils/formatters_test.dart`
+  - `citta/lib/screens/settings/bells_section.dart`
+  - `citta/lib/screens/settings/bg_music_section.dart`
+  - `citta/lib/services/audio_service.dart`
+  - `citta/pubspec.yaml`
+  - `citta/test/screens/settings/settings_sections_test.dart`
+  - `citta/lib/screens/settings/audio_picker.dart`
+- Searched remaining call sites with `rg -n "backgroundMusic|startBackgroundMusic\\(|custom:" citta/lib citta/test`
+- Ran `/home/harsha/flutter/flutter/bin/flutter test test/screens/settings/settings_sections_test.dart`
+  - Result: passes
+- Ran `/home/harsha/flutter/flutter/bin/flutter test test/services/audio_service_test.dart`
   - Result: passes
 
 ## Summary
 
-No findings on the current revision. The shared formatter utility now centralizes the duplicated logic without preserving the earlier locale-formatting bug, and the targeted formatter tests pass.
+The earlier missing-file issue is resolved now that [audio_picker.dart](/home/harsha/workspace/Citta/citta/lib/screens/settings/audio_picker.dart:1) is tracked. The normalization itself still looks correct: background music is stored with the same `custom:<path>` convention as bell selections, `AudioService.startBackgroundMusic()` remains backward-compatible with legacy raw paths, and the targeted settings/audio tests pass.


### PR DESCRIPTION
## Summary
- Store background music selections as `custom:<path>` to match the `bundled:`/`custom:` convention already used for bell sounds, instead of a raw file path.
- `AudioService.startBackgroundMusic()` keeps accepting legacy raw-path configs for backward compatibility.
- Extracted a shared `pickCustomAudioSelection()` helper (used by both the bell and background-music file pickers) and a shared `_resolveSource()` helper in `AudioService` to remove duplicated `bundled:`/`custom:` parsing across `playBell`/`warmUp`/`startBackgroundMusic`.

Closes #16

## Test plan
- [x] `flutter test` — full suite passes (312 tests)
- [x] `flutter analyze` — no issues
- [x] New widget tests cover: picking a file stores `custom:<path>`, cancelling the picker leaves `backgroundMusic` unset, and legacy raw-path configs still render/clear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)