### PR TITLE
fix(audio): restore bell volume after warmUp failure, prevent stale bell playback

### DIFF
--- a/citta/lib/services/audio_service.dart
+++ b/citta/lib/services/audio_service.dart
@@ -94,6 +94,26 @@ class AudioService {
   bool _musicInterrupted = false;
   StreamSubscription<AudioInterruptionEvent>? _interruptionSubscription;
 
+  /// Serializes playBell()/warmUp() bodies so they never interleave on the
+  /// shared _bellPlayer — _RealAudioPlayer.setAsset/setFilePath dispose and
+  /// recreate the underlying player, so a concurrent call landing mid-sequence
+  /// would operate on a player instance the other call has already replaced.
+  /// Deliberately NOT used for stop() calls (handleInterruption/stopAll),
+  /// which must take effect immediately rather than wait behind this queue.
+  Future<void> _bellQueue = Future<void>.value();
+
+  /// Bumped by an immediate stop path (stopAll, non-transient interruption)
+  /// to invalidate any playBell()/warmUp() request queued or in-flight before
+  /// the bump — otherwise queued work would still audibly play after a stop
+  /// that was meant to silence everything.
+  int _bellGeneration = 0;
+
+  Future<T> _queueBellOp<T>(Future<T> Function() operation) {
+    final result = _bellQueue.then((_) => operation());
+    _bellQueue = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
   /// Bell player uses [handleInterruptions: false] — bells are short one-shot
   /// sounds that play without requesting or managing audio focus themselves.
   /// Background music uses the default [handleInterruptions: true] and holds
@@ -184,6 +204,7 @@ class AudioService {
         }
       } else {
         // Non-transient (e.g. phone call): stop all audio immediately.
+        _bellGeneration++;
         try {
           await _bellPlayer.stop();
         } catch (e) {
@@ -240,25 +261,36 @@ class AudioService {
     return allowRawPath ? (isAsset: false, path: id) : null;
   }
 
+  Future<void> _attemptPlayBell(String bellId, int generation) async {
+    if (generation != _bellGeneration) return;
+    final source = _resolveSource(bellId);
+    if (source == null) return;
+    if (source.isAsset) {
+      await _bellPlayer.setAsset(source.path);
+    } else {
+      await _bellPlayer.setFilePath(source.path);
+    }
+    await _bellPlayer.seek(const Duration(milliseconds: 1));
+    if (generation != _bellGeneration) return;
+    await _bellPlayer.play();
+  }
+
   /// Play a bell sound identified by its config string (e.g., "bundled:tibetan_bowl" or "custom:/path/to/file.mp3")
   /// Retries once on failure — ExoPlayer bypass mode can fail on first attempt on some Android versions.
-  Future<void> playBell(String bellId, {bool isRetry = false}) async {
+  ///
+  /// [generation] carries the original request's generation through the
+  /// retry — re-reading _bellGeneration on retry would let a request that a
+  /// stop already invalidated come back to life just because the first,
+  /// stop-induced failure triggered a retry after the generation moved on.
+  Future<void> playBell(String bellId, {bool isRetry = false, int? generation}) async {
+    final effectiveGeneration = generation ?? _bellGeneration;
     try {
-      final source = _resolveSource(bellId);
-      if (source != null) {
-        if (source.isAsset) {
-          await _bellPlayer.setAsset(source.path);
-        } else {
-          await _bellPlayer.setFilePath(source.path);
-        }
-        await _bellPlayer.seek(const Duration(milliseconds: 1));
-        await _bellPlayer.play();
-      }
+      await _queueBellOp(() => _attemptPlayBell(bellId, effectiveGeneration));
     } catch (e) {
       debugPrint('AudioService: playBell failed for "$bellId": $e');
       if (!isRetry) {
         debugPrint('AudioService: retrying playBell for "$bellId"');
-        await playBell(bellId, isRetry: true);
+        await playBell(bellId, isRetry: true, generation: effectiveGeneration);
       }
     }
   }
@@ -272,22 +304,32 @@ class AudioService {
   /// the configured bell sound for a brief instant. Errors are swallowed —
   /// this is a best-effort warm-up only.
   Future<void> warmUp(String bellId) async {
-    try {
-      final source = _resolveSource(bellId);
-      if (source == null) return;
-      if (source.isAsset) {
-        await _bellPlayer.setAsset(source.path);
-      } else {
-        await _bellPlayer.setFilePath(source.path);
+    final source = _resolveSource(bellId);
+    if (source == null) return;
+    final generation = _bellGeneration;
+    await _queueBellOp(() async {
+      if (generation != _bellGeneration) return;
+      try {
+        if (source.isAsset) {
+          await _bellPlayer.setAsset(source.path);
+        } else {
+          await _bellPlayer.setFilePath(source.path);
+        }
+        await _bellPlayer.setVolume(0);
+        await _bellPlayer.seek(const Duration(milliseconds: 1));
+        if (generation != _bellGeneration) return;
+        await _bellPlayer.play();
+        await _bellPlayer.stop();
+      } catch (e) {
+        debugPrint('AudioService: warmUp failed (non-fatal): $e');
+      } finally {
+        try {
+          await _bellPlayer.setVolume(1);
+        } catch (e) {
+          debugPrint('AudioService: warmUp volume restore failed: $e');
+        }
       }
-      await _bellPlayer.setVolume(0);
-      await _bellPlayer.seek(const Duration(milliseconds: 1));
-      await _bellPlayer.play();
-      await _bellPlayer.stop();
-      await _bellPlayer.setVolume(1);
-    } catch (e) {
-      debugPrint('AudioService: warmUp failed (non-fatal): $e');
-    }
+    });
   }
 
   /// Start background music playback (looping).
@@ -334,6 +376,7 @@ class AudioService {
 
   /// Stop all audio.
   Future<void> stopAll() async {
+    _bellGeneration++;
     await _bellPlayer.stop();
     await stopBackgroundMusic();
   }

--- a/citta/test/services/audio_service_test.dart
+++ b/citta/test/services/audio_service_test.dart
@@ -15,23 +15,55 @@ class FakeAudioPlayer implements AudioPlayerBase {
   bool throwOnPause = false;
   bool throwOnPlay = false;
   bool throwOnStop = false;
+  bool throwOnSeek = false;
+  bool throwOnMuteVolume = false;
+  bool throwOnRestoreVolume = false;
+  bool throwOnPlayOnce = false;
 
   String? lastAsset;
   String? lastFilePath;
   LoopMode? lastLoopMode;
   double? lastVolume;
 
+  // Lets a test pause execution right before a named method's body runs, to
+  // deterministically construct interleavings (e.g. proving two calls are
+  // serialized rather than racing on shared player state).
+  String? _gateMethod;
+  Completer<void>? _gate;
+
+  void gateOn(String method) {
+    _gateMethod = method;
+    _gate = Completer<void>();
+  }
+
+  void releaseGate() {
+    _gate?.complete();
+    _gateMethod = null;
+    _gate = null;
+  }
+
+  Future<void> _maybeAwaitGate(String method) async {
+    if (_gateMethod == method) {
+      await _gate!.future;
+    }
+  }
+
   void _maybeThrow(String method) {
     if (shouldThrow) throw Exception('simulated audio failure');
     if (method == 'pause' && throwOnPause) throw Exception('simulated pause failure');
     if (method == 'play' && throwOnPlay) throw Exception('simulated play failure');
     if (method == 'stop' && throwOnStop) throw Exception('simulated stop failure');
+    if (method == 'seek' && throwOnSeek) throw Exception('simulated seek failure');
   }
 
   @override
   Future<void> setAsset(String path) async {
     _maybeThrow('setAsset');
     lastAsset = path;
+    // Mirrors _RealAudioPlayer, which disposes and recreates the underlying
+    // just_audio player (default volume 1.0) on every setAsset/setFilePath
+    // call — any prior mute doesn't survive a fresh load in production.
+    lastVolume = 1.0;
     calls.add('setAsset:$path');
   }
 
@@ -39,6 +71,7 @@ class FakeAudioPlayer implements AudioPlayerBase {
   Future<void> setFilePath(String path) async {
     _maybeThrow('setFilePath');
     lastFilePath = path;
+    lastVolume = 1.0;
     calls.add('setFilePath:$path');
   }
 
@@ -51,19 +84,32 @@ class FakeAudioPlayer implements AudioPlayerBase {
 
   @override
   Future<void> setVolume(double volume) async {
+    await _maybeAwaitGate('setVolume');
     _maybeThrow('setVolume');
+    if (volume == 0 && throwOnMuteVolume) {
+      throw Exception('simulated setVolume(0) failure');
+    }
+    if (volume == 1 && throwOnRestoreVolume) {
+      throw Exception('simulated setVolume(1) failure');
+    }
     lastVolume = volume;
     calls.add('setVolume:$volume');
   }
 
   @override
   Future<void> seek(Duration position) async {
+    await _maybeAwaitGate('seek');
     _maybeThrow('seek');
     calls.add('seek:${position.inMilliseconds}ms');
   }
 
   @override
   Future<void> play() async {
+    await _maybeAwaitGate('play');
+    if (throwOnPlayOnce) {
+      throwOnPlayOnce = false;
+      throw Exception('simulated one-shot play failure');
+    }
     _maybeThrow('play');
     calls.add('play');
   }
@@ -357,6 +403,202 @@ void main() {
         service.warmUp('bundled:temple_bells'),
         completes,
       );
+    });
+
+    test('41. restores volume to 1.0 when seek() throws after setVolume(0)',
+        () async {
+      bellPlayer.throwOnSeek = true;
+
+      await service.warmUp('bundled:temple_bells');
+
+      expect(bellPlayer.lastVolume, 1.0);
+    });
+
+    test('42. restores volume to 1.0 when play() throws after setVolume(0)',
+        () async {
+      bellPlayer.throwOnPlay = true;
+
+      await service.warmUp('bundled:temple_bells');
+
+      expect(bellPlayer.lastVolume, 1.0);
+    });
+
+    test('43. restores volume to 1.0 when stop() throws after setVolume(0)',
+        () async {
+      bellPlayer.throwOnStop = true;
+
+      await service.warmUp('bundled:temple_bells');
+
+      expect(bellPlayer.lastVolume, 1.0);
+    });
+
+    test('44. restores volume to 1.0 when setVolume(0) itself throws',
+        () async {
+      bellPlayer.throwOnMuteVolume = true;
+
+      await service.warmUp('bundled:temple_bells');
+
+      expect(bellPlayer.lastVolume, 1.0);
+    });
+
+    test(
+        '45. does not throw when both the sequence and the volume-restore itself fail',
+        () async {
+      bellPlayer.throwOnStop = true;
+      bellPlayer.throwOnRestoreVolume = true;
+
+      await expectLater(
+        service.warmUp('bundled:temple_bells'),
+        completes,
+      );
+    });
+
+    test(
+        '46. playBell() is unaffected by a prior muted player, since loading a '
+        'new source resets volume like the real player', () async {
+      // Simulate a player left muted by some prior operation, independent of
+      // whether warmUp()'s own restore logic ran.
+      await bellPlayer.setVolume(0);
+      bellPlayer.calls.clear();
+
+      await service.playBell('bundled:singing_bell');
+
+      expect(bellPlayer.lastVolume, 1.0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // concurrency — warmUp() and playBell() share one _bellPlayer
+  // -------------------------------------------------------------------------
+
+  group('concurrency', () {
+    test(
+        '47. serializes warmUp() and playBell() so they never interleave on '
+        'the shared player', () async {
+      bellPlayer.gateOn('setVolume'); // blocks warmUp() right after setAsset
+
+      final warmUpFuture = service.warmUp('bundled:temple_bells');
+      await Future<void>.delayed(Duration.zero);
+
+      final playBellFuture = service.playBell('bundled:singing_bell');
+      await Future<void>.delayed(Duration.zero);
+
+      // playBell() must be queued behind the still-blocked warmUp(), not
+      // running concurrently against the same player.
+      expect(
+        bellPlayer.calls,
+        isNot(contains('setAsset:assets/sounds/singing-bell.mp3')),
+      );
+
+      bellPlayer.releaseGate();
+      await warmUpFuture;
+      await playBellFuture;
+
+      final warmUpRestoreIndex = bellPlayer.calls.indexOf('setVolume:1.0');
+      final playBellAssetIndex =
+          bellPlayer.calls.indexOf('setAsset:assets/sounds/singing-bell.mp3');
+      expect(warmUpRestoreIndex, greaterThanOrEqualTo(0));
+      expect(playBellAssetIndex, greaterThan(warmUpRestoreIndex));
+    });
+
+    test(
+        '48. a bell queued behind an in-flight warmUp() does not play after '
+        'stopAll() invalidates it', () async {
+      bellPlayer.gateOn('setVolume'); // blocks warmUp() right after setAsset
+
+      final warmUpFuture = service.warmUp('bundled:temple_bells');
+      await Future<void>.delayed(Duration.zero);
+
+      final playBellFuture = service.playBell('bundled:singing_bell');
+      await Future<void>.delayed(Duration.zero);
+
+      await service.stopAll();
+
+      bellPlayer.releaseGate();
+      await warmUpFuture;
+      await playBellFuture;
+
+      expect(
+        bellPlayer.calls,
+        isNot(contains('setAsset:assets/sounds/singing-bell.mp3')),
+      );
+      expect(bellPlayer.calls, isNot(contains('play')));
+    });
+
+    test(
+        'aborts an in-flight warmUp() before play() when stopAll() '
+        'invalidates it mid-sequence, but still restores volume', () async {
+      bellPlayer.gateOn('seek'); // blocks after setAsset + setVolume(0)
+
+      final warmUpFuture = service.warmUp('bundled:temple_bells');
+      await Future<void>.delayed(Duration.zero);
+
+      await service.stopAll();
+
+      bellPlayer.releaseGate();
+      await warmUpFuture;
+
+      expect(bellPlayer.calls, isNot(contains('play')));
+      expect(bellPlayer.lastVolume, 1.0);
+    });
+
+    test(
+        'a bell queued behind an in-flight warmUp() does not play after a '
+        'non-transient interruption invalidates it', () async {
+      bellPlayer.gateOn('setVolume'); // blocks warmUp() right after setAsset
+
+      final warmUpFuture = service.warmUp('bundled:temple_bells');
+      await Future<void>.delayed(Duration.zero);
+
+      final playBellFuture = service.playBell('bundled:singing_bell');
+      await Future<void>.delayed(Duration.zero);
+
+      await service.handleInterruption(began: true, transient: false);
+
+      bellPlayer.releaseGate();
+      await warmUpFuture;
+      await playBellFuture;
+
+      expect(
+        bellPlayer.calls,
+        isNot(contains('setAsset:assets/sounds/singing-bell.mp3')),
+      );
+    });
+
+    test(
+        'a bell requested after stopAll() plays normally (generation only '
+        'invalidates work queued before the stop)', () async {
+      await service.stopAll();
+      bellPlayer.calls.clear();
+
+      await service.playBell('bundled:singing_bell');
+
+      expect(
+        bellPlayer.calls,
+        containsAllInOrder([
+          'setAsset:assets/sounds/singing-bell.mp3',
+          'seek:1ms',
+          'play',
+        ]),
+      );
+    });
+
+    test(
+        'a retry after a stop-induced failure does not resurrect a pre-stop '
+        'bell request', () async {
+      bellPlayer.gateOn('play');
+      bellPlayer.throwOnPlayOnce = true;
+
+      final playBellFuture = service.playBell('bundled:temple_bells');
+      await Future<void>.delayed(Duration.zero); // let it reach the play() gate
+
+      // Invalidate the in-flight request's generation while it's stuck.
+      await service.stopAll();
+
+      bellPlayer.releaseGate();
+      await playBellFuture;
+
+      expect(bellPlayer.calls, isNot(contains('play')));
     });
   });
 

--- a/docs/codex-review
+++ b/docs/codex-review
@@ -67,3 +67,34 @@ The implementation now memoizes the in-flight `Future<String>` in [storage_servi
 ## Summary
 
 No findings on the current revision. The branch addresses the exact race called out in issue `#18`, preserves retry semantics after failure, and the targeted tests plus analyzer run pass.
+
+---
+
+## Scope
+
+Review of the current local changes for GitHub issue `#21`: `Bug: AudioService.warmUp can leave bell player permanently muted after failure`.
+
+Issue requirement reviewed against:
+
+- Ensure `warmUp()` restores bell-player volume after failures
+- Avoid introducing new bell playback regressions while fixing warm-up
+- Keep interruption and stop behavior consistent with existing semantics
+
+## Findings
+
+No code-review findings in the current branch state.
+
+## Verification
+
+- Reviewed issue `#21` via `gh issue view 21 --repo harsha-kadekar/citta --json number,title,body,state,url,labels`
+- Inspected the local diff in:
+  - `citta/lib/services/audio_service.dart`
+  - `citta/test/services/audio_service_test.dart`
+- Ran `/home/harsha/flutter/flutter/bin/flutter test test/services/audio_service_test.dart`
+  - Result: passes
+- Ran `/home/harsha/flutter/flutter/bin/flutter analyze lib/services/audio_service.dart test/services/audio_service_test.dart`
+  - Result: passes
+
+## Summary
+
+No findings on the current revision. The fix now covers the full issue chain in [audio_service.dart](/home/harsha/workspace/Citta/citta/lib/services/audio_service.dart:105): `warmUp()` restores bell volume in a `finally` path, queued bell work is invalidated across `stopAll()` and non-transient interruptions, and `playBell()` carries the original generation through its retry so a stop-induced first failure cannot resurrect a pre-stop bell request. The expanded concurrency tests in [audio_service_test.dart](/home/harsha/workspace/Citta/citta/test/services/audio_service_test.dart:474) exercise the earlier stop/interruption races directly, and the focused test/analyzer runs pass.


### PR DESCRIPTION
## Summary
- Fixes #21: `AudioService.warmUp()` restores bell-player volume in a `try/finally` instead of only on the success path, so a mid-sequence failure (after `setVolume(0)`) no longer leaves the bell permanently muted.
- Adds a serialization queue (`_bellQueue`) so `playBell()`/`warmUp()` never interleave on the shared `_bellPlayer`, since `_RealAudioPlayer.setAsset`/`setFilePath` dispose and recreate the underlying player on every call.
- Adds a `_bellGeneration` counter so `stopAll()` and non-transient interruptions invalidate any bell work that was queued or in-flight before the stop — including through `playBell()`'s retry-on-failure path, which previously could resurrect a pre-stop bell request if its first attempt threw for stop-related reasons.

Both regressions above were caught by an automated Codex review of the branch and confirmed by temporarily reverting each fix and observing the corresponding test fail exactly as predicted before restoring it.

## Test plan
- [x] `flutter test test/services/audio_service_test.dart` — all tests pass (53 in this file)
- [x] `flutter test` — full suite passes (326 tests)
- [x] `flutter analyze` — no issues
- [x] Manually verified each of the three fixes by disabling it and confirming the corresponding new regression test fails for the right reason, then restoring it

🤖 Generated with [Claude Code](https://claude.com/claude-code)